### PR TITLE
refactor: Rename SpannerContainer methods to be consistant with PostgresContainer

### DIFF
--- a/spanner.go
+++ b/spanner.go
@@ -92,8 +92,8 @@ func NewSpannerContainer(ctx context.Context, imageVersion string) (*SpannerCont
 	}, nil
 }
 
-// CreateTestDatabase creates a database with dbName. Each test should create their own database for testing
-func (sc *SpannerContainer) CreateTestDatabase(ctx context.Context, dbName string) (*SpannerDB, error) {
+// CreateDatabase creates a database with dbName. Each test should create their own database for testing
+func (sc *SpannerContainer) CreateDatabase(ctx context.Context, dbName string) (*SpannerDB, error) {
 	dbName = sc.validDatabaseName(dbName)
 
 	db, err := newSpannerDatabase(ctx, sc.admin, sc.projectID, sc.instanceID, dbName, sc.opts...)

--- a/spanner_test.go
+++ b/spanner_test.go
@@ -74,7 +74,7 @@ func TestSpanner_FullMigration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
-			db, err := container.CreateTestDatabase(ctx, tt.name)
+			db, err := container.CreateDatabase(ctx, tt.name)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("SpannerContainer.CreateTestDatabase() error = %v, wantErr %v", err, tt.wantErr)
 			}


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
refactor: Rename SpannerContainer methods to be consistent with PostgresContainer (32)

refactor!: Changed the method name on `SpannerContainer` from `CreateTestDatabase()` to `CreateDatabase()`
END_COMMIT_OVERRIDE