### PR TITLE
fix: Close client when calling close on SpannerMigrationService

### DIFF
--- a/spanner_db.go
+++ b/spanner_db.go
@@ -96,7 +96,6 @@ func (db *SpannerDB) migrateUp(source string, spannerInstance migratedb.Driver) 
 		return errors.Wrapf(err, "migrate.NewWithDatabaseInstance(): fileURL=%s, db=%s", source, db.dbStr)
 	}
 	defer m.Close()
-	m.Log = new(logger)
 
 	if _, _, err := m.Version(); !errors.Is(err, migrate.ErrNilVersion) {
 		if err := m.Force(-1); err != nil {
@@ -130,7 +129,6 @@ func (db *SpannerDB) MigrateDown(sourceURL string) error {
 		return errors.Wrapf(err, "migrate.NewWithDatabaseInstance(): fileURL=%s, db=%s", sourceURL, db.dbStr)
 	}
 	defer m.Close()
-	m.Log = new(logger)
 
 	if err := m.Down(); err != nil {
 		return errors.Wrap(err, "migrate.Migrate.Down()")


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: Close client when calling close on SpannerMigrationService (#100)

cleanup: Enable metrics for SpannerMigrationService (#100)
END_COMMIT_OVERRIDE