### PR TITLE
fix: SSLMode was defaulted to disable

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -105,7 +105,7 @@ func ExamplePostgresMigrator_MigrateUpSchema() {
 	}
 	defer db.Close()
 
-	migrator := NewPostgresMigrator(container.superUsername, "password", container.host, container.port.Port(), db.dbName, "disable")
+	migrator := NewPostgresMigrator(container.superUsername, "password", container.host, container.port.Port(), db.dbName, SSLModeDisable)
 
 	if err := migrator.MigrateUpSchema(ctx, "file://testdata/postgres/migrations"); err != nil {
 		panic(err)

--- a/examples_test.go
+++ b/examples_test.go
@@ -105,7 +105,7 @@ func ExamplePostgresMigrator_MigrateUpSchema() {
 	}
 	defer db.Close()
 
-	migrator := NewPostgresMigrator(container.superUsername, "password", container.host, container.port.Port(), db.dbName)
+	migrator := NewPostgresMigrator(container.superUsername, "password", container.host, container.port.Port(), db.dbName, "disable")
 
 	if err := migrator.MigrateUpSchema(ctx, "file://testdata/postgres/migrations"); err != nil {
 		panic(err)

--- a/postgres.go
+++ b/postgres.go
@@ -18,6 +18,24 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
+// SSLMode represents the sslmode parameter for PostgreSQL connections.
+type SSLMode string
+
+const (
+	// SSLModeDisable disables SSL entirely. Use only for local test containers.
+	SSLModeDisable SSLMode = "disable"
+	// SSLModeAllow prefers non-SSL but will use SSL if the server requires it.
+	SSLModeAllow SSLMode = "allow"
+	// SSLModePrefer prefers SSL but will use non-SSL if the server does not support it.
+	SSLModePrefer SSLMode = "prefer"
+	// SSLModeRequire requires SSL but does not verify the server certificate.
+	SSLModeRequire SSLMode = "require"
+	// SSLModeVerifyCA requires SSL and verifies the server certificate is signed by a trusted CA.
+	SSLModeVerifyCA SSLMode = "verify-ca"
+	// SSLModeVerifyFull requires SSL, verifies the CA, and verifies the server hostname matches the certificate.
+	SSLModeVerifyFull SSLMode = "verify-full"
+)
+
 const (
 	defaultPostgresHost     = "localhost"
 	defaultPostgresPort     = "5432"
@@ -116,7 +134,7 @@ func (pc *PostgresContainer) CreateDatabase(ctx context.Context, dbName string) 
 	}
 
 	// create extension in the newly created table
-	db, err = openDB(ctx, PostgresConnStr(pc.superUsername, pc.password, pc.host, pc.port.Port(), dbName, "disable"))
+	db, err = openDB(ctx, PostgresConnStr(pc.superUsername, pc.password, pc.host, pc.port.Port(), dbName, SSLModeDisable))
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +148,7 @@ func (pc *PostgresContainer) CreateDatabase(ctx context.Context, dbName string) 
 		return nil, errors.Wrapf(err, "failed to create extension btree_gist in database=%q", dbName)
 	}
 
-	u, err := openDB(ctx, PostgresConnStr(pc.unprivilegedUsername, pc.password, pc.host, pc.port.Port(), dbName, "disable"))
+	u, err := openDB(ctx, PostgresConnStr(pc.unprivilegedUsername, pc.password, pc.host, pc.port.Port(), dbName, SSLModeDisable))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to connect to database=%q with %s", dbName, pc.unprivilegedUsername)
 	}
@@ -145,7 +163,7 @@ func (pc *PostgresContainer) CreateDatabase(ctx context.Context, dbName string) 
 		Pool:    u,
 		dbName:  dbName,
 		schema:  pc.unprivilegedUsername,
-		connStr: PostgresConnStr(pc.unprivilegedUsername, pc.password, pc.host, pc.port.Port(), dbName, "disable"),
+		connStr: PostgresConnStr(pc.unprivilegedUsername, pc.password, pc.host, pc.port.Port(), dbName, SSLModeDisable),
 	}, nil
 }
 
@@ -164,7 +182,7 @@ func (pc *PostgresContainer) superUserConnection(ctx context.Context, database s
 	pool, ok := pc.superUserConnections[database]
 	if !ok || pool == nil || pool.Ping(ctx) != nil {
 		var err error
-		pool, err = openDB(ctx, PostgresConnStr(pc.superUsername, pc.password, pc.host, pc.port.Port(), database, "disable"))
+		pool, err = openDB(ctx, PostgresConnStr(pc.superUsername, pc.password, pc.host, pc.port.Port(), database, SSLModeDisable))
 		if err != nil {
 			return nil, err
 		}
@@ -215,11 +233,11 @@ func (pc *PostgresContainer) validDatabaseName(dbName string) string {
 }
 
 // PostgresConnStr builds a postgres connection URL.
-// sslMode sets the sslmode query parameter (e.g. "require", "verify-full", "disable").
-// Pass an empty string to use the default, which is "require".
-func PostgresConnStr(username, password, host, port, database, sslMode string) string {
+// sslMode sets the sslmode query parameter.
+// Pass an empty string to use the default, which is [SSLModeRequire].
+func PostgresConnStr(username, password, host, port, database string, sslMode SSLMode) string {
 	if sslMode == "" {
-		sslMode = "require"
+		sslMode = SSLModeRequire
 	}
 
 	return fmt.Sprintf("postgresql://%s:%s@%s:%s/%s?sslmode=%s",
@@ -228,7 +246,7 @@ func PostgresConnStr(username, password, host, port, database, sslMode string) s
 		host,
 		port,
 		database,
-		sslMode,
+		string(sslMode),
 	)
 }
 

--- a/postgres.go
+++ b/postgres.go
@@ -116,7 +116,7 @@ func (pc *PostgresContainer) CreateDatabase(ctx context.Context, dbName string) 
 	}
 
 	// create extension in the newly created table
-	db, err = openDB(ctx, PostgresConnStr(pc.superUsername, pc.password, pc.host, pc.port.Port(), dbName))
+	db, err = openDB(ctx, PostgresConnStr(pc.superUsername, pc.password, pc.host, pc.port.Port(), dbName, "disable"))
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (pc *PostgresContainer) CreateDatabase(ctx context.Context, dbName string) 
 		return nil, errors.Wrapf(err, "failed to create extension btree_gist in database=%q", dbName)
 	}
 
-	u, err := openDB(ctx, PostgresConnStr(pc.unprivilegedUsername, pc.password, pc.host, pc.port.Port(), dbName))
+	u, err := openDB(ctx, PostgresConnStr(pc.unprivilegedUsername, pc.password, pc.host, pc.port.Port(), dbName, "disable"))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to connect to database=%q with %s", dbName, pc.unprivilegedUsername)
 	}
@@ -145,7 +145,7 @@ func (pc *PostgresContainer) CreateDatabase(ctx context.Context, dbName string) 
 		Pool:    u,
 		dbName:  dbName,
 		schema:  pc.unprivilegedUsername,
-		connStr: PostgresConnStr(pc.unprivilegedUsername, pc.password, pc.host, pc.port.Port(), dbName),
+		connStr: PostgresConnStr(pc.unprivilegedUsername, pc.password, pc.host, pc.port.Port(), dbName, "disable"),
 	}, nil
 }
 
@@ -164,7 +164,7 @@ func (pc *PostgresContainer) superUserConnection(ctx context.Context, database s
 	pool, ok := pc.superUserConnections[database]
 	if !ok || pool == nil || pool.Ping(ctx) != nil {
 		var err error
-		pool, err = openDB(ctx, PostgresConnStr(pc.superUsername, pc.password, pc.host, pc.port.Port(), database))
+		pool, err = openDB(ctx, PostgresConnStr(pc.superUsername, pc.password, pc.host, pc.port.Port(), database, "disable"))
 		if err != nil {
 			return nil, err
 		}
@@ -214,13 +214,21 @@ func (pc *PostgresContainer) validDatabaseName(dbName string) string {
 	return dbName
 }
 
-func PostgresConnStr(username, password, host, port, database string) string {
-	return fmt.Sprintf("postgresql://%s:%s@%s:%s/%s?sslmode=disable",
+// PostgresConnStr builds a postgres connection URL.
+// sslMode sets the sslmode query parameter (e.g. "require", "verify-full", "disable").
+// Pass an empty string to use the default, which is "require".
+func PostgresConnStr(username, password, host, port, database, sslMode string) string {
+	if sslMode == "" {
+		sslMode = "require"
+	}
+
+	return fmt.Sprintf("postgresql://%s:%s@%s:%s/%s?sslmode=%s",
 		username,
 		password,
 		host,
 		port,
 		database,
+		sslMode,
 	)
 }
 

--- a/postgres_db.go
+++ b/postgres_db.go
@@ -18,7 +18,7 @@ type PostgresDatabase struct {
 }
 
 // NewPostgresDatabase creates a new database and schema, then connects to it.
-func NewPostgresDatabase(ctx context.Context, username, password, host, port, databaseToCreate, schemaToCreate, sslMode string) (*PostgresDatabase, error) {
+func NewPostgresDatabase(ctx context.Context, username, password, host, port, databaseToCreate, schemaToCreate string, sslMode SSLMode) (*PostgresDatabase, error) {
 	// a. Construct connection string for a default database (e.g., "postgres")
 	defaultDBConnStr := PostgresConnStr(username, password, host, port, "postgres", sslMode)
 

--- a/postgres_db.go
+++ b/postgres_db.go
@@ -18,9 +18,9 @@ type PostgresDatabase struct {
 }
 
 // NewPostgresDatabase creates a new database and schema, then connects to it.
-func NewPostgresDatabase(ctx context.Context, username, password, host, port, databaseToCreate, schemaToCreate string) (*PostgresDatabase, error) {
+func NewPostgresDatabase(ctx context.Context, username, password, host, port, databaseToCreate, schemaToCreate, sslMode string) (*PostgresDatabase, error) {
 	// a. Construct connection string for a default database (e.g., "postgres")
-	defaultDBConnStr := PostgresConnStr(username, password, host, port, "postgres")
+	defaultDBConnStr := PostgresConnStr(username, password, host, port, "postgres", sslMode)
 
 	// b. Open a temporary admin connection to this default database
 	adminPool, err := openDB(ctx, defaultDBConnStr)
@@ -36,7 +36,7 @@ func NewPostgresDatabase(ctx context.Context, username, password, host, port, da
 	}
 
 	// e. Construct the connection string for the newly created database
-	targetDBConnStr := PostgresConnStr(username, password, host, port, databaseToCreate)
+	targetDBConnStr := PostgresConnStr(username, password, host, port, databaseToCreate, sslMode)
 
 	// f. Open the main connection pool to this target database
 	mainPool, err := openDB(ctx, targetDBConnStr)

--- a/postgres_migration.go
+++ b/postgres_migration.go
@@ -2,6 +2,7 @@ package dbinitiator
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-playground/errors/v5"
 	"github.com/golang-migrate/migrate/v4"
@@ -15,12 +16,16 @@ var _ Migrator = (*PostgresMigrator)(nil)
 
 // NewPostgresMigrator returns a new [PostgresMigrator].
 // It does not attempt to create the database or schema.
-func NewPostgresMigrator(username, password, host, port, database string) *PostgresMigrator {
-	connStr := PostgresConnStr(username, password, host, port, database)
-
-	return &PostgresMigrator{
-		connStr: connStr,
+func NewPostgresMigrator(username, password, host, port, database, sslMode string) *PostgresMigrator {
+	if sslMode == "" {
+		sslMode = "require"
 	}
+
+	connStr := fmt.Sprintf("postgresql://%s:%s@%s:%s/%s?sslmode=%s",
+		username, password, host, port, database, sslMode,
+	)
+
+	return &PostgresMigrator{connStr: connStr}
 }
 
 // MigrateUp will migrate all the way up, applying all up migrations from the sourceURL

--- a/postgres_migration.go
+++ b/postgres_migration.go
@@ -16,10 +16,10 @@ var _ Migrator = (*PostgresMigrator)(nil)
 // NewPostgresMigrator returns a new [PostgresMigrator].
 // It does not attempt to create the database or schema.
 //
-// sslMode sets the sslmode query parameter (e.g. "require", "verify-full", "disable").
-// Pass an empty string to use the default, which is "require".
-// Use "disable" only for local test containers.
-func NewPostgresMigrator(username, password, host, port, database, sslMode string) *PostgresMigrator {
+// sslMode sets the sslmode query parameter.
+// Pass an empty string to use the default, which is [SSLModeRequire].
+// Use [SSLModeDisable] only for local test containers.
+func NewPostgresMigrator(username, password, host, port, database string, sslMode SSLMode) *PostgresMigrator {
 	return &PostgresMigrator{
 		connStr: PostgresConnStr(username, password, host, port, database, sslMode),
 	}

--- a/postgres_migration.go
+++ b/postgres_migration.go
@@ -2,7 +2,6 @@ package dbinitiator
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-playground/errors/v5"
 	"github.com/golang-migrate/migrate/v4"
@@ -16,16 +15,14 @@ var _ Migrator = (*PostgresMigrator)(nil)
 
 // NewPostgresMigrator returns a new [PostgresMigrator].
 // It does not attempt to create the database or schema.
+//
+// sslMode sets the sslmode query parameter (e.g. "require", "verify-full", "disable").
+// Pass an empty string to use the default, which is "require".
+// Use "disable" only for local test containers.
 func NewPostgresMigrator(username, password, host, port, database, sslMode string) *PostgresMigrator {
-	if sslMode == "" {
-		sslMode = "require"
+	return &PostgresMigrator{
+		connStr: PostgresConnStr(username, password, host, port, database, sslMode),
 	}
-
-	connStr := fmt.Sprintf("postgresql://%s:%s@%s:%s/%s?sslmode=%s",
-		username, password, host, port, database, sslMode,
-	)
-
-	return &PostgresMigrator{connStr: connStr}
 }
 
 // MigrateUp will migrate all the way up, applying all up migrations from the sourceURL

--- a/postgres_migration_test.go
+++ b/postgres_migration_test.go
@@ -46,7 +46,7 @@ func TestNewPostgresMigrator(t *testing.T) {
 			defer initialDB.Close()
 
 			// Execution: Call NewPostgresMigrator
-			pgMigrator := NewPostgresMigrator(pgContainer.unprivilegedUsername, pgContainer.password, pgContainer.host, pgContainer.port.Port(), tt.name)
+			pgMigrator := NewPostgresMigrator(pgContainer.unprivilegedUsername, pgContainer.password, pgContainer.host, pgContainer.port.Port(), tt.name, "disable")
 
 			if pgMigrator == nil {
 				t.Fatalf("PostgresMigration should not be nil for db %s", tt.name)

--- a/postgres_migration_test.go
+++ b/postgres_migration_test.go
@@ -46,7 +46,7 @@ func TestNewPostgresMigrator(t *testing.T) {
 			defer initialDB.Close()
 
 			// Execution: Call NewPostgresMigrator
-			pgMigrator := NewPostgresMigrator(pgContainer.unprivilegedUsername, pgContainer.password, pgContainer.host, pgContainer.port.Port(), tt.name, "disable")
+			pgMigrator := NewPostgresMigrator(pgContainer.unprivilegedUsername, pgContainer.password, pgContainer.host, pgContainer.port.Port(), tt.name, SSLModeDisable)
 
 			if pgMigrator == nil {
 				t.Fatalf("PostgresMigration should not be nil for db %s", tt.name)

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -155,7 +155,7 @@ func TestPostgres_FullMigrationWithNewPostgresDatabase(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
-			db, err := NewPostgresDatabase(ctx, pgC.superUsername, pgC.password, pgC.host, pgC.port.Port(), tt.name, pgC.unprivilegedUsername)
+			db, err := NewPostgresDatabase(ctx, pgC.superUsername, pgC.password, pgC.host, pgC.port.Port(), tt.name, pgC.unprivilegedUsername, "disable")
 			if err != nil {
 				t.Fatalf("NewPostgresDatabase() error = %v", err)
 			}

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -155,7 +155,7 @@ func TestPostgres_FullMigrationWithNewPostgresDatabase(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
-			db, err := NewPostgresDatabase(ctx, pgC.superUsername, pgC.password, pgC.host, pgC.port.Port(), tt.name, pgC.unprivilegedUsername, "disable")
+			db, err := NewPostgresDatabase(ctx, pgC.superUsername, pgC.password, pgC.host, pgC.port.Port(), tt.name, pgC.unprivilegedUsername, SSLModeDisable)
 			if err != nil {
 				t.Fatalf("NewPostgresDatabase() error = %v", err)
 			}


### PR DESCRIPTION
Through a chain of calls ssl mode was always set to "disable" in this package. This PR addresses that by allowing the ssl mode to be passed to the NewPostgresMigrator function

I've opted to have sslmode set to require if not specified otherwise