### PR TITLE
feat: support forced migration version override

### DIFF
--- a/spanner_migration.go
+++ b/spanner_migration.go
@@ -22,9 +22,15 @@ type SpannerMigrator struct {
 	connectionString      string
 	dataMigrationsTable   string
 	schemaMigrationsTable string
+	versionOverrideConfig VersionOverrideConfig
 	databaseName          string
 	admin                 *spannerDB.DatabaseAdminClient
 	client                *spanner.Client
+}
+
+type VersionOverrideConfig struct {
+	shouldOverride  bool
+	overrideVersion int
 }
 
 var _ Migrator = (*SpannerMigrator)(nil)
@@ -61,6 +67,17 @@ func NewSpannerMigrator(ctx context.Context, projectID, instanceID, dbName strin
 // WithSchemaMigrationsTable allows setting the schema migration table to be used
 func (s *SpannerMigrator) WithSchemaMigrationsTable(table string) *SpannerMigrator {
 	s.schemaMigrationsTable = table
+
+	return s
+}
+
+// WithUnsafeForcedSchemaVersion allows forcing a specific schema version, without verifying that
+// the schema corresponding to the forced version exists in the database
+func (s *SpannerMigrator) WithUnsafeForcedSchemaVersion(version int) *SpannerMigrator {
+	s.versionOverrideConfig = VersionOverrideConfig{
+		shouldOverride:  true,
+		overrideVersion: version,
+	}
 
 	return s
 }
@@ -173,6 +190,12 @@ func (s *SpannerMigrator) migrateUp(migrationsTable, sourceURL string) error {
 
 	if err := m.Up(); err != nil {
 		return errors.Wrapf(err, "migrate.Migrate.Up(): %s", sourceURL)
+	}
+
+	if s.versionOverrideConfig.shouldOverride {
+		if err := m.Force(s.versionOverrideConfig.overrideVersion); err != nil {
+			return errors.Wrapf(err, "migrate.Force()")
+		}
 	}
 
 	return nil

--- a/spanner_migration.go
+++ b/spanner_migration.go
@@ -94,7 +94,7 @@ func (s *SpannerMigrator) WithDataMigrationsTable(table string) *SpannerMigrator
 // Use for DDL migrations
 func (s *SpannerMigrator) MigrateUpSchema(ctx context.Context, sourceURL string) error {
 	ccclogger.FromCtx(ctx).Infof("Applying schema migrations from %s", sourceURL)
-	if err := s.migrateUp(s.schemaMigrationsTable, sourceURL); err != nil {
+	if err := s.migrateUp(s.schemaMigrationsTable, sourceURL, s.versionOverrideConfig); err != nil {
 		return errors.Wrap(err, "SpannerMigrator.migrateUp()")
 	}
 
@@ -106,7 +106,7 @@ func (s *SpannerMigrator) MigrateUpSchema(ctx context.Context, sourceURL string)
 // Use for DML migrations
 func (s *SpannerMigrator) MigrateUpData(ctx context.Context, sourceURL string) error {
 	ccclogger.FromCtx(ctx).Infof("Applying data migrations from %s", sourceURL)
-	if err := s.migrateUp(s.dataMigrationsTable, sourceURL); err != nil {
+	if err := s.migrateUp(s.dataMigrationsTable, sourceURL, VersionOverrideConfig{shouldOverride: false}); err != nil {
 		return errors.Wrap(err, "SpannerMigrator.migrateUp()")
 	}
 
@@ -182,7 +182,7 @@ func (s *SpannerMigrator) Close() error {
 	return nil
 }
 
-func (s *SpannerMigrator) migrateUp(migrationsTable, sourceURL string) error {
+func (s *SpannerMigrator) migrateUp(migrationsTable, sourceURL string, versionOverride VersionOverrideConfig) error {
 	m, err := s.newMigrate(migrationsTable, sourceURL)
 	if err != nil {
 		return errors.Wrap(err, "SpannerMigrator.newMigrate()")
@@ -192,8 +192,8 @@ func (s *SpannerMigrator) migrateUp(migrationsTable, sourceURL string) error {
 		return errors.Wrapf(err, "migrate.Migrate.Up(): %s", sourceURL)
 	}
 
-	if s.versionOverrideConfig.shouldOverride {
-		if err := m.Force(s.versionOverrideConfig.overrideVersion); err != nil {
+	if versionOverride.shouldOverride {
+		if err := m.Force(versionOverride.overrideVersion); err != nil {
 			return errors.Wrapf(err, "migrate.Force()")
 		}
 	}

--- a/spanner_migration.go
+++ b/spanner_migration.go
@@ -22,13 +22,13 @@ type SpannerMigrator struct {
 	connectionString      string
 	dataMigrationsTable   string
 	schemaMigrationsTable string
-	versionOverrideConfig VersionOverrideConfig
+	versionOverrideConfig versionOverrideConfig
 	databaseName          string
 	admin                 *spannerDB.DatabaseAdminClient
 	client                *spanner.Client
 }
 
-type VersionOverrideConfig struct {
+type versionOverrideConfig struct {
 	shouldOverride  bool
 	overrideVersion int
 }
@@ -74,7 +74,7 @@ func (s *SpannerMigrator) WithSchemaMigrationsTable(table string) *SpannerMigrat
 // WithUnsafeForcedSchemaVersion allows forcing a specific schema version, without verifying that
 // the schema corresponding to the forced version exists in the database
 func (s *SpannerMigrator) WithUnsafeForcedSchemaVersion(version int) *SpannerMigrator {
-	s.versionOverrideConfig = VersionOverrideConfig{
+	s.versionOverrideConfig = versionOverrideConfig{
 		shouldOverride:  true,
 		overrideVersion: version,
 	}
@@ -106,7 +106,7 @@ func (s *SpannerMigrator) MigrateUpSchema(ctx context.Context, sourceURL string)
 // Use for DML migrations
 func (s *SpannerMigrator) MigrateUpData(ctx context.Context, sourceURL string) error {
 	ccclogger.FromCtx(ctx).Infof("Applying data migrations from %s", sourceURL)
-	if err := s.migrateUp(s.dataMigrationsTable, sourceURL, VersionOverrideConfig{shouldOverride: false}); err != nil {
+	if err := s.migrateUp(s.dataMigrationsTable, sourceURL, versionOverrideConfig{}); err != nil {
 		return errors.Wrap(err, "SpannerMigrator.migrateUp()")
 	}
 
@@ -182,7 +182,7 @@ func (s *SpannerMigrator) Close() error {
 	return nil
 }
 
-func (s *SpannerMigrator) migrateUp(migrationsTable, sourceURL string, versionOverride VersionOverrideConfig) error {
+func (s *SpannerMigrator) migrateUp(migrationsTable, sourceURL string, versionOverride versionOverrideConfig) error {
 	m, err := s.newMigrate(migrationsTable, sourceURL)
 	if err != nil {
 		return errors.Wrap(err, "SpannerMigrator.newMigrate()")

--- a/spanner_migration_test.go
+++ b/spanner_migration_test.go
@@ -223,6 +223,94 @@ func TestSpannerMigrator_MigrateUpSchema(t *testing.T) {
 	}
 }
 
+func TestSpannerMigrator_MigrateUpForcedVersionSchema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := NewSpannerContainer(ctx, "latest")
+	if err != nil {
+		t.Fatalf("NewSpannerContainer(): %s", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	type args struct {
+		sourceURL string
+	}
+	type assertion struct {
+		name  string
+		query string
+	}
+	tests := []struct {
+		name           string
+		args           args
+		wantErr        bool
+		postAssertions []assertion
+	}{
+		{
+			name: "schema migration with forced final database version",
+			args: args{
+				sourceURL: "file://testdata/spanner/migrations_full",
+			},
+			wantErr: false,
+			postAssertions: []assertion{
+				{
+					name:  "Version override is applied",
+					query: "SELECT EXISTS(SELECT 1 FROM SchemaMigrations WHERE Version = 10501)",
+				},
+				{
+					name:  "Version override is applied and is not dirty",
+					query: "SELECT EXISTS(SELECT 1 FROM SchemaMigrations WHERE Version = 10501 AND Dirty = FALSE)",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dbName := genDBName()
+			db, err := container.CreateDatabase(ctx, dbName)
+			if err != nil {
+				t.Fatalf("SpannerContainer.CreateDatabase() error = %v", err)
+			}
+			defer func() {
+				if err := db.DropDatabase(context.Background()); err != nil {
+					t.Errorf("DB.DropDatabase() err=%s", err)
+				}
+				if err := db.Close(); err != nil {
+					t.Errorf("DB.Close() err=%s", err)
+				}
+			}()
+
+			svc, err := NewSpannerMigrator(ctx, container.projectID, container.instanceID, dbName, container.opts...)
+			svc.WithUnsafeForcedSchemaVersion(10501)
+
+			if err != nil {
+				t.Fatalf("NewSpannerMigrator() error = %v", err)
+			}
+			defer func() {
+				if err := svc.Close(); err != nil {
+					t.Errorf("SpannerMigrator.Close() err=%s", err)
+				}
+			}()
+
+			if err := svc.MigrateUpSchema(ctx, tt.args.sourceURL); (err != nil) != tt.wantErr {
+				t.Errorf("SpannerMigrator.MigrateUpSchema() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Run post-migration assertions only if migration succeeded
+			if !tt.wantErr {
+				for _, a := range tt.postAssertions {
+					if result, err := assertionQuery(ctx, db.Client, a.query); err != nil {
+						t.Fatalf("Post-assertion %q failed to execute: %v", a.name, err)
+					} else if !result {
+						t.Errorf("Post-assertion %q returned false", a.name)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestSpannerMigrator_MigrateUpData(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR:

- [x] Adds a config option to `SpannerMigrator` to allow overriding the final version displayed in the database migrations table, via a new `WithUnsafeForcedSchemaVersion` builder function.
- [x] Modifies the `migrateUp` function to accept this override config, and apply the override version at the end of the migration if instructed by the config to do so.
- [x] Updates `MigrateUpSchema` and `MigrateUpData` to pass in appropriate config options.

NOTE: Right now, there's asymmetry between data and schema migrations because data migrations are extremely quick and don't require a forced version override that consolidated schema migrations do